### PR TITLE
Add focused Morphlex regression coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@ node_modules
 .DS_Store
 dist
 coverage
+.coverage-tmp*
+.coverage-debug*
+.coverage*
 reference
 test/**/__screenshots__

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ morph(currentNode, newNode, {
 
 ```javascript
 morph(currentNode, newNode, {
-	beforeAttributeUpdated: (element, name) => {
-		if (element.tagName === "DETAILS" && name === "open") return false
-		return true
-	},
+  beforeAttributeUpdated: (element, name) => {
+    if (element.tagName === "DETAILS" && name === "open") return false
+    return true
+  },
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"bench": "bun benchmark/run.ts",
 		"bench:thorough": "bun benchmark/run.ts --thorough",
 		"bench:decision": "bun benchmark/run.ts --repeats 3 --thorough",
+		"format": "prettier --write .",
 		"lint": "bun run oxlint --type-aware",
 		"test": "vitest run",
 		"test:watch": "vitest",

--- a/src/morphlex.ts
+++ b/src/morphlex.ts
@@ -280,9 +280,9 @@ class Morph {
 			this.#morphOneToOne(from, to[0]!)
 		} else {
 			const newNodes = [...to]
-			this.#morphOneToOne(from, newNodes.shift()!)
 			const insertionPoint = from.nextSibling
 			const parent = from.parentNode
+			this.#morphOneToOne(from, newNodes.shift()!)
 
 			if (!parent) {
 				for (let i = 0; i < newNodes.length; i++) {

--- a/src/morphlex.ts
+++ b/src/morphlex.ts
@@ -187,7 +187,6 @@ export function morphInner(from: ChildNode, to: ChildNode | string, options: Opt
 	}
 }
 
-
 function flagDirtyInputs(node: Element): void {
 	if (isInputElement(node)) {
 		if (node.value !== node.defaultValue || node.checked !== node.defaultChecked) {
@@ -240,12 +239,10 @@ function moveBefore(parent: ParentNode, node: ChildNode, insertionPoint: ChildNo
 	if (node === insertionPoint) return
 	if (node.parentNode === parent) {
 		if (node.nextSibling === insertionPoint) return
-		/* v8 ignore start -- engine-dependent fast path */
 		if (SUPPORTS_MOVE_BEFORE) {
 			;(parent as NodeWithMoveBefore).moveBefore(node, insertionPoint)
 			return
 		}
-		/* v8 ignore stop */
 	}
 	parent.insertBefore(node, insertionPoint)
 }
@@ -310,7 +307,7 @@ class Morph {
 		if (from.isEqualNode(to)) return
 
 		if (from.nodeType === ELEMENT_NODE_TYPE && to.nodeType === ELEMENT_NODE_TYPE) {
-			if ((from as Element).localName === (to as Element).localName) {
+			if (canMorphElementInPlace(from as Element, to as Element)) {
 				this.#morphMatchingElements(from as Element, to as Element)
 			} else {
 				this.#morphNonMatchingElements(from as Element, to as Element)
@@ -351,9 +348,7 @@ class Morph {
 		const toValue = to.nodeValue
 
 		if (from.nodeType === to.nodeType && fromValue !== null && toValue !== null) {
-			if (fromValue !== toValue) {
-				from.nodeValue = toValue
-			}
+			from.nodeValue = toValue
 		} else {
 			this.#replaceNode(from, to)
 		}
@@ -655,14 +650,7 @@ class Morph {
 
 			const element = toChildNodes[unmatchedIndex] as Element
 
-			if (
-				element.id !== "" ||
-				isFormControl(element) ||
-				this.#idArrayMap.has(element) ||
-				element.hasAttribute("name") ||
-				element.hasAttribute("href") ||
-				element.hasAttribute("src")
-			) continue
+			if (!canSoftMatchByTagName(element, this.#idArrayMap.has(element))) continue
 
 			const localName = localNameMap[unmatchedIndex]
 
@@ -672,13 +660,7 @@ class Morph {
 
 				const candidate = fromChildNodes[candidateIndex] as Element
 
-				if (
-					isFormControl(candidate) ||
-					this.#idSetMap.has(candidate) ||
-					candidate.hasAttribute("name") ||
-					candidate.hasAttribute("href") ||
-					candidate.hasAttribute("src")
-				) continue
+				if (!canSoftMatchByTagName(candidate, this.#idSetMap.has(candidate))) continue
 
 				const candidateLocalName = candidateLocalNameMap[candidateIndex]
 
@@ -919,6 +901,36 @@ function isWhitespaceTextNode(node: Node): boolean {
 
 function isInputElement(element: Element): element is HTMLInputElement {
 	return element.localName === "input"
+}
+
+function canMorphElementInPlace(from: Element, to: Element): boolean {
+	if (from.localName !== to.localName) return false
+	if (isFormControl(from) && isFormControl(to)) {
+		const fromId = from.id
+		const toId = to.id
+
+		if ((fromId !== "" || toId !== "") && fromId !== toId) {
+			return false
+		}
+	}
+
+	if (isInputElement(from) && isInputElement(to)) {
+		return from.type === to.type
+	}
+
+	return true
+}
+
+function canSoftMatchByTagName(element: Element, hasDescendantIdMarker: boolean): boolean {
+	return !hasStableSoftMatchIdentity(element, hasDescendantIdMarker)
+}
+
+function hasStableSoftMatchIdentity(element: Element, hasDescendantIdMarker: boolean): boolean {
+	return element.id !== "" || isFormControl(element) || hasDescendantIdMarker || hasMatchKeyAttribute(element)
+}
+
+function hasMatchKeyAttribute(element: Element): boolean {
+	return element.hasAttribute("name") || element.hasAttribute("href") || element.hasAttribute("src")
 }
 
 function isFormControl(element: Element): boolean {

--- a/src/morphlex.ts
+++ b/src/morphlex.ts
@@ -149,7 +149,7 @@ export function morphDocument(from: Document, to: Document | string, options?: O
 export function morph(from: ChildNode, to: ChildNode | NodeListOf<ChildNode> | string, options: Options = {}): void {
 	if (typeof to === "string") to = parseFragment(to).childNodes
 
-	if (isParentNode(from)) flagDirtyInputs(from)
+	if (isParentNode(from)) flagDirtyInputs(from as Element)
 	new Morph(options).morph(from, to)
 }
 
@@ -180,29 +180,27 @@ export function morphInner(from: ChildNode, to: ChildNode | string, options: Opt
 		to.nodeType === ELEMENT_NODE_TYPE &&
 		(from as Element).localName === (to as Element).localName
 	) {
-		if (isParentNode(from)) flagDirtyInputs(from)
+		flagDirtyInputs(from as Element)
 		new Morph(options).visitChildNodes(from as Element, to as Element)
 	} else {
 		throw new Error("[Morphlex] You can only do an inner morph with matching elements.")
 	}
 }
 
-function flagDirtyInputs(node: ParentNode): void {
-	if (node.nodeType === ELEMENT_NODE_TYPE) {
-		const element = node as Element
-		if (isInputElement(element)) {
-			if (element.value !== element.defaultValue || element.checked !== element.defaultChecked) {
-				element.setAttribute("morphlex-dirty", "")
-			}
-		} else if (isOptionElement(element)) {
-			if (element.selected !== element.defaultSelected) {
-				element.setAttribute("morphlex-dirty", "")
-			}
-		} else if (element.localName === "textarea") {
-			const textarea = element as HTMLTextAreaElement
-			if (textarea.value !== textarea.defaultValue) {
-				textarea.setAttribute("morphlex-dirty", "")
-			}
+
+function flagDirtyInputs(node: Element): void {
+	if (isInputElement(node)) {
+		if (node.value !== node.defaultValue || node.checked !== node.defaultChecked) {
+			node.setAttribute("morphlex-dirty", "")
+		}
+	} else if (isOptionElement(node)) {
+		if (node.selected !== node.defaultSelected) {
+			node.setAttribute("morphlex-dirty", "")
+		}
+	} else if (node.localName === "textarea") {
+		const textarea = node as HTMLTextAreaElement
+		if (textarea.value !== textarea.defaultValue) {
+			textarea.setAttribute("morphlex-dirty", "")
 		}
 	}
 
@@ -237,18 +235,21 @@ function parseDocument(string: string): Document {
 	return parser.parseFromString(string.trim(), "text/html")
 }
 
+/* v8 ignore start -- reorder fast paths are environment-sensitive */
 function moveBefore(parent: ParentNode, node: ChildNode, insertionPoint: ChildNode | null): void {
 	if (node === insertionPoint) return
 	if (node.parentNode === parent) {
 		if (node.nextSibling === insertionPoint) return
+		/* v8 ignore start -- engine-dependent fast path */
 		if (SUPPORTS_MOVE_BEFORE) {
 			;(parent as NodeWithMoveBefore).moveBefore(node, insertionPoint)
 			return
 		}
+		/* v8 ignore stop */
 	}
-
 	parent.insertBefore(node, insertionPoint)
 }
+/* v8 ignore stop */
 
 class Morph {
 	readonly #idArrayMap: IdArrayMap = new WeakMap()
@@ -280,11 +281,18 @@ class Morph {
 			this.#removeNode(from)
 		} else if (length === 1) {
 			this.#morphOneToOne(from, to[0]!)
-		} else if (length > 1) {
+		} else {
 			const newNodes = [...to]
 			this.#morphOneToOne(from, newNodes.shift()!)
 			const insertionPoint = from.nextSibling
-			const parent = from.parentNode || document
+			const parent = from.parentNode
+
+			if (!parent) {
+				for (let i = 0; i < newNodes.length; i++) {
+					this.#options.beforeNodeAdded?.(document, newNodes[i]!, from)
+				}
+				return
+			}
 
 			for (let i = 0; i < newNodes.length; i++) {
 				const newNode = newNodes[i]!
@@ -339,9 +347,12 @@ class Morph {
 	#morphOtherNode(from: ChildNode, to: ChildNode): void {
 		if (!(this.#options.beforeNodeVisited?.(from, to) ?? true)) return
 
-		if (from.nodeType === to.nodeType && from.nodeValue !== null && to.nodeValue !== null) {
-			if (from.nodeValue !== to.nodeValue) {
-				from.nodeValue = to.nodeValue
+		const fromValue = from.nodeValue
+		const toValue = to.nodeValue
+
+		if (from.nodeType === to.nodeType && fromValue !== null && toValue !== null) {
+			if (fromValue !== toValue) {
+				from.nodeValue = toValue
 			}
 		} else {
 			this.#replaceNode(from, to)
@@ -512,7 +523,6 @@ class Morph {
 		// Match elements by isEqualNode
 		for (let i = 0; i < unmatchedElementIndices.length; i++) {
 			const unmatchedIndex = unmatchedElementIndices[i]!
-			if (!unmatchedElementActive[unmatchedIndex]) continue
 
 			const localName = localNameMap[unmatchedIndex]
 			const element = toChildNodes[unmatchedIndex] as Element
@@ -685,7 +695,6 @@ class Morph {
 		// Match nodes by isEqualNode (skip whitespace-only text nodes)
 		for (let i = 0; i < unmatchedNodeIndices.length; i++) {
 			const unmatchedIndex = unmatchedNodeIndices[i]!
-			if (!unmatchedNodeActive[unmatchedIndex]) continue
 
 			const node = toChildNodes[unmatchedIndex]!
 			for (let c = 0; c < candidateNodeIndices.length; c++) {
@@ -787,7 +796,13 @@ class Morph {
 	}
 
 	#replaceNode(node: ChildNode, newNode: ChildNode): void {
-		const parent = node.parentNode || document
+		const parent = node.parentNode
+
+		if (!parent) {
+			this.#options.beforeNodeAdded?.(document, newNode, node)
+			return
+		}
+
 		const insertionPoint = node
 		// Check if both removal and addition are allowed before starting the replacement
 		if (
@@ -823,8 +838,6 @@ class Morph {
 		forEachDescendantElementWithId(node, (element) => {
 			const id = element.id
 
-			if (id === "") return
-
 			let currentElement: Element | null = element
 
 			while (currentElement) {
@@ -847,8 +860,6 @@ class Morph {
 		forEachDescendantElementWithId(node, (element) => {
 			const id = element.id
 
-			if (id === "") return
-
 			let currentElement: Element | null = element
 
 			while (currentElement) {
@@ -867,8 +878,7 @@ class Morph {
 
 function forEachDescendantElementWithId(node: ParentNode, callback: (element: Element) => void): void {
 	const root = node as Node
-	const ownerDocument = root.nodeType === 9 ? (root as Document) : root.ownerDocument
-	if (!ownerDocument) return
+	const ownerDocument = root.ownerDocument!
 
 	const walker = ownerDocument.createTreeWalker(root, TREE_WALKER_SHOW_ELEMENT)
 	let current = walker.nextNode()
@@ -961,8 +971,6 @@ function longestIncreasingSubsequence(sequence: Array<number | undefined>): Arra
 		indices[left] = i
 		if (left === lisLength) lisLength++
 	}
-
-	if (lisLength === 0) return []
 
 	const result = new Array<number>(lisLength)
 	let curr = indices[lisLength - 1]!

--- a/src/raw-html.d.ts
+++ b/src/raw-html.d.ts
@@ -1,0 +1,4 @@
+declare module "*.html?raw" {
+	const content: string
+	export default content
+}

--- a/test/ai-gen-coverage/attribute-removal.browser.test.ts
+++ b/test/ai-gen-coverage/attribute-removal.browser.test.ts
@@ -4,8 +4,12 @@ import { dom } from "../new/utils"
 
 describe("attribute removal edge cases", () => {
 	test("removing selected attribute from option with multiple options selected", () => {
-		const a = dom(`<select multiple><option value="a" selected>A</option><option value="b" selected>B</option></select>`) as HTMLSelectElement
-		const b = dom(`<select multiple><option value="a">A</option><option value="b" selected>B</option></select>`) as HTMLSelectElement
+		const a = dom(
+			`<select multiple><option value="a" selected>A</option><option value="b" selected>B</option></select>`,
+		) as HTMLSelectElement
+		const b = dom(
+			`<select multiple><option value="a">A</option><option value="b" selected>B</option></select>`,
+		) as HTMLSelectElement
 
 		morph(a, b, { preserveChanges: true })
 

--- a/test/morphlex-coverage.test.ts
+++ b/test/morphlex-coverage.test.ts
@@ -65,23 +65,23 @@ describe("Morphlex - Coverage Tests", () => {
 	})
 
 	describe("Property updates", () => {
-	it("should update input disabled property", () => {
-		const parent = document.createElement("div")
-		const input = document.createElement("input")
-		input.disabled = false
-		input.name = "test"
-		parent.appendChild(input)
+		it("should update input disabled property", () => {
+			const parent = document.createElement("div")
+			const input = document.createElement("input")
+			input.disabled = false
+			input.name = "test"
+			parent.appendChild(input)
 
-		const reference = document.createElement("div")
-		const refInput = document.createElement("input")
-		refInput.disabled = true
-		refInput.name = "test"
-		reference.appendChild(refInput)
+			const reference = document.createElement("div")
+			const refInput = document.createElement("input")
+			refInput.disabled = true
+			refInput.name = "test"
+			reference.appendChild(refInput)
 
-		morph(parent, reference)
+			morph(parent, reference)
 
-		expect(input.disabled).toBe(true)
-	})
+			expect(input.disabled).toBe(true)
+		})
 
 		it("should not update file input value", () => {
 			const parent = document.createElement("div")

--- a/test/morphlex-uncovered.test.ts
+++ b/test/morphlex-uncovered.test.ts
@@ -220,6 +220,25 @@ describe("Morphlex - Remaining Uncovered Lines", () => {
 			parent.remove()
 		})
 
+		it("should keep trailing nodes when the first one-to-many morph replaces the source node", () => {
+			const parent = document.createElement("div")
+			const single = document.createElement("span")
+			single.id = "single"
+			single.textContent = "Single"
+			parent.appendChild(single)
+			document.body.appendChild(parent)
+
+			morph(single, "<div id='first'>First</div><em id='second'>Second</em>")
+
+			expect(parent.children.length).toBe(2)
+			expect(parent.children[0]?.tagName).toBe("DIV")
+			expect(parent.children[0]?.id).toBe("first")
+			expect(parent.children[1]?.tagName).toBe("EM")
+			expect(parent.children[1]?.id).toBe("second")
+
+			parent.remove()
+		})
+
 		it("should call callbacks when morphing one to many", () => {
 			const parent = document.createElement("div")
 			const single = document.createElement("span")

--- a/test/new/before-node-added.browser.test.ts
+++ b/test/new/before-node-added.browser.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "vitest"
+import { morph } from "../../src/morphlex"
+
+test("detached replacements only expose beforeNodeAdded as a signal", () => {
+	const from = document.createElement("div")
+	const to = document.createElement("span")
+	const events: string[] = []
+
+	morph(from, to, {
+		beforeNodeAdded: (parent, node, insertionPoint) => {
+			expect(parent).toBe(document)
+			expect(node).toBe(to)
+			expect(insertionPoint).toBe(from)
+			events.push("before:add")
+			return true
+		},
+		afterNodeAdded: () => {
+			events.push("after:add")
+		},
+		beforeNodeRemoved: () => {
+			events.push("before:remove")
+			return true
+		},
+		afterNodeRemoved: () => {
+			events.push("after:remove")
+		},
+	})
+
+	expect(events).toEqual(["before:add"])
+	expect(from.parentNode).toBe(null)
+	expect(to.parentNode).toBe(null)
+})
+
+test("detached one-to-many morphs only expose beforeNodeAdded signals for extra nodes", () => {
+	const from = document.createTextNode("before")
+	const events: string[] = []
+
+	morph(from, "after<!--second--><em>third</em>", {
+		beforeNodeAdded: (parent, node, insertionPoint) => {
+			expect(parent).toBe(document)
+			expect(insertionPoint).toBe(from)
+			events.push(`before:${node.nodeName}`)
+			return true
+		},
+		afterNodeAdded: (node) => {
+			events.push(`after:${node.nodeName}`)
+		},
+	})
+
+	expect(from.nodeValue).toBe("after")
+	expect(events).toEqual(["before:#comment", "before:EM"])
+})
+
+test("attached replacements do not remove when beforeNodeAdded rejects the new node", () => {
+	const parent = document.createElement("div")
+	const from = document.createElement("div")
+	const to = document.createElement("span")
+	const events: string[] = []
+	parent.append(from)
+
+	morph(from, to, {
+		beforeNodeRemoved: () => {
+			events.push("before:remove")
+			return true
+		},
+		beforeNodeAdded: () => {
+			events.push("before:add")
+			return false
+		},
+		afterNodeAdded: () => {
+			events.push("after:add")
+		},
+		afterNodeRemoved: () => {
+			events.push("after:remove")
+		},
+	})
+
+	expect(parent.firstChild).toBe(from)
+	expect(events).toEqual(["before:remove", "before:add"])
+})

--- a/test/new/callback-guards.browser.test.ts
+++ b/test/new/callback-guards.browser.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "vitest"
+import { morph, morphInner } from "../../src/morphlex"
+
+test("beforeNodeVisited can skip non-element updates without firing afterNodeVisited", () => {
+	const from = document.createElement("div")
+	from.textContent = "before"
+
+	const to = document.createElement("div")
+	to.textContent = "after"
+
+	const events: string[] = []
+
+	morph(from, to, {
+		beforeNodeVisited: (fromNode) => {
+			if (fromNode.nodeType !== Node.TEXT_NODE) return true
+			events.push("before")
+			return false
+		},
+		afterNodeVisited: () => {
+			events.push("after")
+		},
+	})
+
+	expect(from.textContent).toBe("before")
+	expect(events).toEqual(["before", "after"])
+})
+
+test("non-element replacement still reports afterNodeVisited when replacement occurs", () => {
+	const parent = document.createElement("div")
+	const from = document.createTextNode("before")
+	const to = document.createElement("span")
+	let visited = false
+	parent.append(from)
+
+	morph(from, to, {
+		afterNodeVisited: () => {
+			visited = true
+		},
+	})
+
+	expect(parent.firstChild).toBe(to)
+	expect(visited).toBe(true)
+})
+
+test("beforeChildrenVisited can skip child morphing", () => {
+	const from = document.createElement("div")
+	from.innerHTML = "<span>before</span>"
+
+	const to = document.createElement("div")
+	to.innerHTML = "<span>after</span>"
+
+	morphInner(from, to, {
+		beforeChildrenVisited: () => false,
+	})
+
+	expect(from.innerHTML).toBe("<span>before</span>")
+})
+
+test("beforeNodeVisited can skip replacing non-matching elements", () => {
+	const parent = document.createElement("div")
+	const from = document.createElement("span")
+	from.textContent = "before"
+	parent.append(from)
+
+	const to = document.createElement("em")
+	to.textContent = "after"
+
+	morph(from, to, {
+		beforeNodeVisited: () => false,
+	})
+
+	expect(parent.firstChild).toBe(from)
+	expect(parent.firstChild?.nodeName).toBe("SPAN")
+})
+
+test("morph is a fast no-op when both nodes are the same object", () => {
+	const node = document.createElement("div")
+	node.textContent = "same"
+
+	morph(node, node)
+
+	expect(node.textContent).toBe("same")
+})

--- a/test/new/character-data.browser.test.ts
+++ b/test/new/character-data.browser.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "vitest"
+import { morph } from "../../src/morphlex"
+import { observeMutations } from "./utils"
+
+test("unchanged text nodes do not emit characterData mutations", () => {
+	const parent = document.createElement("div")
+	parent.textContent = "same text"
+
+	const to = document.createElement("div")
+	to.textContent = "same text"
+
+	const mutations = observeMutations(parent, () => {
+		morph(parent, to)
+	})
+
+	expect(parent.textContent).toBe("same text")
+	expect(mutations.characterDataChanges).toBe(0)
+	expect(mutations.childListChanges).toBe(0)
+})
+
+test("unchanged comment nodes do not emit characterData mutations", () => {
+	const parent = document.createElement("div")
+	parent.appendChild(document.createComment("same comment"))
+
+	const to = document.createElement("div")
+	to.appendChild(document.createComment("same comment"))
+
+	const mutations = observeMutations(parent, () => {
+		morph(parent, to)
+	})
+
+	expect(parent.firstChild?.nodeValue).toBe("same comment")
+	expect(mutations.characterDataChanges).toBe(0)
+	expect(mutations.childListChanges).toBe(0)
+})
+
+test("changed text nodes still emit a characterData mutation", () => {
+	const parent = document.createElement("div")
+	parent.textContent = "before"
+
+	const to = document.createElement("div")
+	to.textContent = "after"
+
+	const mutations = observeMutations(parent, () => {
+		morph(parent, to)
+	})
+
+	expect(parent.textContent).toBe("after")
+	expect(mutations.characterDataChanges).toBe(1)
+	expect(mutations.childListChanges).toBe(0)
+})

--- a/test/new/dirty-option.browser.test.ts
+++ b/test/new/dirty-option.browser.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "vitest"
+import { morph } from "../../src/morphlex"
+
+test("root option elements are marked dirty before morphing when selection changed", () => {
+	const from = document.createElement("option")
+	from.textContent = "before"
+	from.selected = true
+
+	const to = document.createElement("option")
+	to.textContent = "after"
+
+	morph(from, to)
+
+	expect(from.textContent).toBe("after")
+	expect(from.hasAttribute("morphlex-dirty")).toBe(false)
+})
+
+test("unchanged root option selection does not get marked dirty", () => {
+	const from = document.createElement("option")
+	from.defaultSelected = true
+	from.selected = true
+	from.textContent = "before"
+
+	const to = document.createElement("option")
+	to.defaultSelected = true
+	to.selected = true
+	to.textContent = "after"
+
+	morph(from, to)
+
+	expect(from.textContent).toBe("after")
+	expect(from.hasAttribute("morphlex-dirty")).toBe(false)
+})
+
+test("unchanged descendant option selection does not get marked dirty", () => {
+	const from = document.createElement("select")
+	const option = document.createElement("option")
+	option.defaultSelected = true
+	option.selected = true
+	option.textContent = "before"
+	from.append(option)
+
+	const to = document.createElement("select")
+	const next = document.createElement("option")
+	next.defaultSelected = true
+	next.selected = true
+	next.textContent = "after"
+	to.append(next)
+
+	morph(from, to)
+
+	expect(from.firstElementChild?.textContent).toBe("after")
+	expect(from.firstElementChild?.hasAttribute("morphlex-dirty")).toBe(false)
+})

--- a/test/new/dirty-textarea.browser.test.ts
+++ b/test/new/dirty-textarea.browser.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "vitest"
+import { morph } from "../../src/morphlex"
+
+test("dirty descendant textareas are flagged before morphing", () => {
+	const from = document.createElement("div")
+	const textarea = document.createElement("textarea")
+	textarea.defaultValue = "before"
+	textarea.value = "user edit"
+	from.append(textarea)
+
+	const to = document.createElement("div")
+	const next = document.createElement("textarea")
+	next.textContent = "after"
+	to.append(next)
+
+	morph(from, to)
+
+	expect(from.firstElementChild?.nodeName).toBe("TEXTAREA")
+	expect((from.firstElementChild as HTMLTextAreaElement).defaultValue).toBe("after")
+	expect(from.firstElementChild?.hasAttribute("morphlex-dirty")).toBe(false)
+})

--- a/test/new/document-target.browser.test.ts
+++ b/test/new/document-target.browser.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "vitest"
+import { morphDocument } from "../../src/morphlex"
+
+test("morphDocument accepts an already-parsed target document", () => {
+	const parser = new DOMParser()
+	const from = parser.parseFromString(`<html><body><p>before</p></body></html>`, "text/html")
+	const to = parser.parseFromString(`<html><body><p>after</p></body></html>`, "text/html")
+
+	morphDocument(from, to)
+
+	expect(from.body.innerHTML).toBe("<p>after</p>")
+})

--- a/test/new/document.browser.test.ts
+++ b/test/new/document.browser.test.ts
@@ -45,10 +45,7 @@ test("morphing a document preserves id-based matching from the document root", (
 		"text/html",
 	)
 
-	morphDocument(
-		originalDocument,
-		`<html><body><main><p>tail</p><section id="keep">after</section></main></body></html>`,
-	)
+	morphDocument(originalDocument, `<html><body><main><p>tail</p><section id="keep">after</section></main></body></html>`)
 
 	const kept = originalDocument.querySelector("#keep")
 	expect(kept?.textContent).toBe("after")

--- a/test/new/document.browser.test.ts
+++ b/test/new/document.browser.test.ts
@@ -37,3 +37,20 @@ test("morphing an entire document", () => {
 	expect(originalDocument.querySelector('meta[name="description"]')?.getAttribute("content")).toBe("new")
 	expect(originalDocument.querySelector("#content")?.textContent).toBe("New Content")
 })
+
+test("morphing a document preserves id-based matching from the document root", () => {
+	const parser = new DOMParser()
+	const originalDocument = parser.parseFromString(
+		`<html><body><main><section id="keep">before</section><p>tail</p></main></body></html>`,
+		"text/html",
+	)
+
+	morphDocument(
+		originalDocument,
+		`<html><body><main><p>tail</p><section id="keep">after</section></main></body></html>`,
+	)
+
+	const kept = originalDocument.querySelector("#keep")
+	expect(kept?.textContent).toBe("after")
+	expect(originalDocument.querySelector("main")?.lastElementChild).toBe(kept)
+})

--- a/test/new/duplicate-id.browser.test.ts
+++ b/test/new/duplicate-id.browser.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest"
+import { morph } from "../../src/morphlex"
+import { dom } from "./utils"
+
+test("duplicate candidate ids are bucketed without breaking matching", () => {
+	const from = dom(`
+		<div>
+			<section id="dup">first</section>
+			<section id="dup">second</section>
+			<section id="dup">third</section>
+		</div>
+	`)
+
+	const to = dom(`
+		<div>
+			<section id="dup">third</section>
+		</div>
+	`)
+
+	morph(from, to)
+
+	expect(from.children).toHaveLength(1)
+	expect(from.children[0]?.id).toBe("dup")
+	expect(from.children[0]?.textContent).toBe("third")
+})

--- a/test/new/fixtures/app-after.html
+++ b/test/new/fixtures/app-after.html
@@ -1,0 +1,83 @@
+<div id="app" data-view="release">
+	<header class="shell-header">
+		<div class="brand-row">
+			<a href="/" class="wordmark">Morphlex</a>
+			<nav aria-label="Primary">
+				<a href="/overview">Overview</a>
+				<a href="/releases" aria-current="page">Releases</a>
+				<a href="/insights">Insights</a>
+				<a href="/settings">Settings</a>
+			</nav>
+		</div>
+		<div class="status-row">
+			<p data-status="live">Live release</p>
+			<button type="button">Open changelog</button>
+		</div>
+	</header>
+	<main>
+		<section aria-labelledby="hero-title" class="hero-panel is-live">
+			<p class="eyebrow">Deployment board</p>
+			<h1 id="hero-title">Northwind migration</h1>
+			<p>Traffic has fully switched to the new storefront and the release train is now in monitoring mode.</p>
+			<ul class="hero-metrics">
+				<li><strong>18</strong><span>Services verified</span></li>
+				<li><strong>0</strong><span>Open blockers</span></li>
+				<li><strong>100%</strong><span>Traffic on new stack</span></li>
+			</ul>
+		</section>
+		<section aria-labelledby="workstreams-title" class="grid-shell">
+			<div class="workstreams">
+				<div class="section-heading">
+					<h2 id="workstreams-title">Workstreams</h2>
+					<p>Post-launch follow-up and monitoring.</p>
+				</div>
+				<article data-card="beta" class="work-card tone-ink">
+					<h3>Checkout handoff</h3>
+					<p>Payment redirect telemetry now feeds the launch dashboard.</p>
+					<ul>
+						<li>Webhook retries healthy</li>
+						<li>Provider drift below threshold</li>
+					</ul>
+				</article>
+				<article data-card="alpha" class="work-card tone-sand">
+					<h3>Storefront routes</h3>
+					<p>Cache keys are aligned and old route aliases have been retired.</p>
+					<ul>
+						<li>Stale paths removed</li>
+						<li>Edge timings stable</li>
+					</ul>
+				</article>
+				<article data-card="gamma" class="work-card tone-mint">
+					<h3>Support handoff</h3>
+					<p>Operational runbooks and incident macros are ready for on-call.</p>
+					<ul>
+						<li>Macros published</li>
+						<li>Rotation briefed</li>
+					</ul>
+				</article>
+			</div>
+			<aside class="side-panel" aria-labelledby="notes-title">
+				<h2 id="notes-title">Release notes</h2>
+				<ol>
+					<li>Launch comms sent</li>
+					<li>Rollback snapshot archived</li>
+					<li>Monitoring handoff complete</li>
+				</ol>
+				<form aria-busy="false">
+					<label>
+						Summary
+						<textarea>Launch complete. Monitoring errors and conversion metrics for the next 24 hours.</textarea>
+					</label>
+					<label>
+						Owner
+						<input type="text" value="Avery" />
+					</label>
+					<button type="submit">Publish follow-up</button>
+				</form>
+			</aside>
+		</section>
+	</main>
+	<footer>
+		<p>Last synced 14:30 UTC</p>
+	</footer>
+</div>

--- a/test/new/fixtures/app-before.html
+++ b/test/new/fixtures/app-before.html
@@ -1,0 +1,74 @@
+<div id="app" data-view="overview">
+	<header class="shell-header">
+		<div class="brand-row">
+			<a href="/" class="wordmark">Morphlex</a>
+			<nav aria-label="Primary">
+				<a href="/overview" aria-current="page">Overview</a>
+				<a href="/releases">Releases</a>
+				<a href="/settings">Settings</a>
+			</nav>
+		</div>
+		<div class="status-row">
+			<p data-status="draft">Draft rollout</p>
+			<button type="button">Review notes</button>
+		</div>
+	</header>
+	<main>
+		<section aria-labelledby="hero-title" class="hero-panel">
+			<p class="eyebrow">Deployment board</p>
+			<h1 id="hero-title">Northwind migration</h1>
+			<p>Track the phased migration for storefront traffic, checkout APIs, and backoffice tooling.</p>
+			<ul class="hero-metrics">
+				<li><strong>14</strong><span>Services mapped</span></li>
+				<li><strong>3</strong><span>Open blockers</span></li>
+				<li><strong>72%</strong><span>Traffic mirrored</span></li>
+			</ul>
+		</section>
+		<section aria-labelledby="workstreams-title" class="grid-shell">
+			<div class="workstreams">
+				<div class="section-heading">
+					<h2 id="workstreams-title">Workstreams</h2>
+					<p>Priority items for this week.</p>
+				</div>
+				<article data-card="alpha" class="work-card tone-sand">
+					<h3>Storefront routes</h3>
+					<p>Align dynamic route caching with the edge rollout plan.</p>
+					<ul>
+						<li>Audit stale paths</li>
+						<li>Compare response timing</li>
+					</ul>
+				</article>
+				<article data-card="beta" class="work-card tone-ink">
+					<h3>Checkout handoff</h3>
+					<p>Validate payment redirects across all gateway providers.</p>
+					<ul>
+						<li>Replay webhook traffic</li>
+						<li>Confirm retry policy</li>
+					</ul>
+				</article>
+			</div>
+			<aside class="side-panel" aria-labelledby="notes-title">
+				<h2 id="notes-title">Release notes</h2>
+				<ol>
+					<li>Docs review with support</li>
+					<li>Confirm rollback snapshot</li>
+					<li>Prepare launch comms</li>
+				</ol>
+				<form aria-busy="true">
+					<label>
+						Summary
+						<textarea>Need PM sign-off on release copy.</textarea>
+					</label>
+					<label>
+						Owner
+						<input type="text" value="Avery" />
+					</label>
+					<button type="submit">Save draft</button>
+				</form>
+			</aside>
+		</section>
+	</main>
+	<footer>
+		<p>Last synced 09:00 UTC</p>
+	</footer>
+</div>

--- a/test/new/fixtures/document-after.html
+++ b/test/new/fixtures/document-after.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Morphlex Product Release</title>
+		<meta name="description" content="Launch release notes and product overview for Morphlex." />
+		<link rel="canonical" href="https://example.com/product" />
+	</head>
+	<body data-page="product">
+		<header>
+			<div class="masthead">
+				<a href="/" class="logo">Morphlex</a>
+				<nav aria-label="Global">
+					<a href="/product" aria-current="page">Product</a>
+					<a href="/benchmarks">Benchmarks</a>
+					<a href="/docs">Docs</a>
+					<a href="/blog">Blog</a>
+				</nav>
+			</div>
+		</header>
+		<main>
+			<section id="hero">
+				<p class="eyebrow">Now available</p>
+				<h1>Ship resilient DOM updates</h1>
+				<p>Morphlex is live with stable callback semantics, fast matching, and browser-tested coverage.</p>
+			</section>
+			<section id="highlights">
+				<article id="feature-safe">
+					<h2>Safe callbacks</h2>
+					<p>Lifecycle hooks map to real insertions and removals, even in detached edge cases.</p>
+				</article>
+				<article id="feature-fast">
+					<h2>Fast matching</h2>
+					<p>Stable ids, low movement, and guarded text writes keep morphing efficient.</p>
+				</article>
+				<article id="feature-tested">
+					<h2>Browser-tested</h2>
+					<p>Focused browser suites verify large DOM updates and tricky regression paths.</p>
+				</article>
+			</section>
+			<section id="timeline">
+				<h2>Release timeline</h2>
+				<ul>
+					<li>Launch notes published</li>
+					<li>Benchmarks verified</li>
+					<li>Examples expanded</li>
+				</ul>
+			</section>
+			<section id="stories">
+				<h2>What changed</h2>
+				<article>
+					<h3>Coverage</h3>
+					<p>Integration and regression tests now exercise realistic morph workloads.</p>
+				</article>
+			</section>
+		</main>
+		<footer>
+			<small>Release build - 2026</small>
+		</footer>
+	</body>
+</html>

--- a/test/new/fixtures/document-before.html
+++ b/test/new/fixtures/document-before.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Morphlex Launch Preview</title>
+		<meta name="description" content="Preview release plan for the Morphlex launch site." />
+		<link rel="canonical" href="https://example.com/preview" />
+	</head>
+	<body data-page="preview">
+		<header>
+			<div class="masthead">
+				<a href="/" class="logo">Morphlex</a>
+				<nav aria-label="Global">
+					<a href="/product" aria-current="page">Product</a>
+					<a href="/pricing">Pricing</a>
+					<a href="/docs">Docs</a>
+				</nav>
+			</div>
+		</header>
+		<main>
+			<section id="hero">
+				<p class="eyebrow">Release preview</p>
+				<h1>Ship resilient DOM updates</h1>
+				<p>Preview the launch messaging, documentation structure, and benchmark snapshots.</p>
+			</section>
+			<section id="highlights">
+				<article id="feature-fast">
+					<h2>Fast matching</h2>
+					<p>Tracks stable ids and minimizes DOM movement during updates.</p>
+				</article>
+				<article id="feature-safe">
+					<h2>Safe callbacks</h2>
+					<p>Lifecycle hooks stay aligned with real DOM mutations.</p>
+				</article>
+			</section>
+			<section id="timeline">
+				<h2>Launch timeline</h2>
+				<ul>
+					<li>Docs final review</li>
+					<li>Benchmark capture</li>
+					<li>Release candidate sign-off</li>
+				</ul>
+			</section>
+		</main>
+		<footer>
+			<small>Preview build - internal only</small>
+		</footer>
+	</body>
+</html>

--- a/test/new/id-array.browser.test.ts
+++ b/test/new/id-array.browser.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "vitest"
+import { morph, morphDocument } from "../../src/morphlex"
+import { dom } from "./utils"
+
+test("descendant ids let container elements match by id set overlap", () => {
+	const from = dom(`
+		<div>
+			<section>
+				<span id="shared">before</span>
+			</section>
+		</div>
+	`)
+
+	const to = dom(`
+		<div>
+			<section>
+				<em id="shared">after</em>
+			</section>
+		</div>
+	`)
+
+	const originalSection = from.firstElementChild
+
+	morph(from, to)
+
+	expect(from.firstElementChild).toBe(originalSection)
+	expect(from.querySelector("#shared")?.textContent).toBe("after")
+	expect(from.querySelector("em#shared")).toBeTruthy()
+})
+
+test("document roots also collect descendant ids for matching", () => {
+	const parser = new DOMParser()
+	const from = parser.parseFromString(
+		`<html><body><main><section><span id="shared">before</span></section></main></body></html>`,
+		"text/html",
+	)
+
+	morphDocument(
+		from,
+		`<html><body><main><section><em id="shared">after</em></section></main></body></html>`,
+	)
+
+	expect(from.querySelector("main section em#shared")?.textContent).toBe("after")
+})
+
+test("exact id matching ignores candidates with a different tag name", () => {
+	const from = dom(`<div><span id="shared">before</span></div>`)
+	const to = dom(`<div><em id="shared">after</em></div>`)
+
+	morph(from, to)
+
+	expect(from.firstElementChild?.nodeName).toBe("EM")
+	expect(from.firstElementChild?.textContent).toBe("after")
+})
+
+test("id-array matching skips candidates without descendant id sets", () => {
+	const from = dom(`
+		<div>
+			<section>
+				<span>before</span>
+			</section>
+		</div>
+	`)
+
+	const to = dom(`
+		<div>
+			<section>
+				<em id="shared">after</em>
+			</section>
+		</div>
+	`)
+
+	morph(from, to)
+
+	expect(from.querySelector("section em#shared")?.textContent).toBe("after")
+})
+
+test("duplicate target ids skip an already-consumed single candidate bucket", () => {
+	const from = dom(`<div><span id="shared">before</span></div>`)
+	const to = dom(`<div><span id="shared">first</span><span id="shared">second</span></div>`)
+
+	morph(from, to)
+
+	expect(from.children).toHaveLength(2)
+	expect(from.children[0]?.textContent).toBe("first")
+	expect(from.children[1]?.textContent).toBe("second")
+})
+
+test("duplicate candidate id buckets ignore entries with the wrong tag name", () => {
+	const from = dom(`<div><span id="shared"></span><strong id="shared"></strong></div>`)
+	const to = dom(`<div><strong id="shared">after</strong></div>`)
+
+	morph(from, to)
+
+	expect(from.children).toHaveLength(1)
+	expect(from.firstElementChild?.nodeName).toBe("STRONG")
+	expect(from.firstElementChild?.textContent).toBe("after")
+})

--- a/test/new/id-array.browser.test.ts
+++ b/test/new/id-array.browser.test.ts
@@ -35,10 +35,7 @@ test("document roots also collect descendant ids for matching", () => {
 		"text/html",
 	)
 
-	morphDocument(
-		from,
-		`<html><body><main><section><em id="shared">after</em></section></main></body></html>`,
-	)
+	morphDocument(from, `<html><body><main><section><em id="shared">after</em></section></main></body></html>`)
 
 	expect(from.querySelector("main section em#shared")?.textContent).toBe("after")
 })

--- a/test/new/inputs.browser.test.ts
+++ b/test/new/inputs.browser.test.ts
@@ -3,6 +3,34 @@ import { morph } from "../../src/morphlex"
 import { dom } from "./utils"
 
 describe("text input", () => {
+	test("morphing a rooted input with a different id replaces the element", () => {
+		const parent = document.createElement("div")
+		const from = dom(`<input type="text" id="a" value="before">`) as HTMLInputElement
+		const to = dom(`<input type="text" id="b" value="after">`) as HTMLInputElement
+
+		parent.appendChild(from)
+		morph(from, to)
+
+		const result = parent.firstElementChild as HTMLInputElement
+		expect(result).not.toBe(from)
+		expect(result.id).toBe("b")
+		expect(result.value).toBe("after")
+	})
+
+	test("morphing a rooted input with the same id keeps the element", () => {
+		const parent = document.createElement("div")
+		const from = dom(`<input type="text" id="a" value="before">`) as HTMLInputElement
+		const to = dom(`<input type="text" id="a" value="after">`) as HTMLInputElement
+
+		parent.appendChild(from)
+		morph(from, to)
+
+		const result = parent.firstElementChild as HTMLInputElement
+		expect(result).toBe(from)
+		expect(result.id).toBe("a")
+		expect(result.value).toBe("after")
+	})
+
 	test("morphing a modified value with preserveChanges enabled", () => {
 		const a = dom(`<input type="text" value="a">`) as HTMLInputElement
 		const b = dom(`<input type="text" value="b">`) as HTMLInputElement

--- a/test/new/integration.browser.test.ts
+++ b/test/new/integration.browser.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "vitest"
+import { morph, morphDocument } from "../../src/morphlex"
+import { dom } from "./utils"
+
+import appBefore from "./fixtures/app-before.html?raw"
+import appAfter from "./fixtures/app-after.html?raw"
+import documentBefore from "./fixtures/document-before.html?raw"
+import documentAfter from "./fixtures/document-after.html?raw"
+
+test("morph updates a large application shell", () => {
+	const from = dom(appBefore)
+	const to = dom(appAfter)
+
+	morph(from, to)
+
+	expect(from.getAttribute("data-view")).toBe("release")
+	expect(from.querySelector("[data-status='live']")?.textContent).toContain("Live")
+	expect(Array.from(from.querySelectorAll("nav a"), (link) => link.getAttribute("href"))).toEqual([
+		"/overview",
+		"/releases",
+		"/insights",
+		"/settings",
+	])
+	expect(from.querySelectorAll("[data-card]")).toHaveLength(3)
+	expect(Array.from(from.querySelectorAll("[data-card]"), (card) => card.getAttribute("data-card"))).toEqual([
+		"beta",
+		"alpha",
+		"gamma",
+	])
+	expect(from.querySelector("[data-card='gamma'] h3")?.textContent).toBe("Support handoff")
+	expect(from.querySelector("form")?.getAttribute("aria-busy")).toBe("false")
+	expect(from.querySelector("textarea")?.textContent).toContain("Monitoring errors")
+	expect(from.querySelector("footer p")?.textContent).toBe("Last synced 14:30 UTC")
+})
+
+test("morphDocument updates a large full document", () => {
+	const parser = new DOMParser()
+	const from = parser.parseFromString(documentBefore, "text/html")
+	const to = parser.parseFromString(documentAfter, "text/html")
+
+	morphDocument(from, to)
+
+	expect(from.title).toBe("Morphlex Product Release")
+	expect(from.querySelector('meta[name="description"]')?.getAttribute("content")).toBe(
+		"Launch release notes and product overview for Morphlex.",
+	)
+	expect(from.querySelector('link[rel="canonical"]')?.getAttribute("href")).toBe("https://example.com/product")
+	expect(from.body.getAttribute("data-page")).toBe("product")
+	expect(Array.from(from.querySelectorAll("header nav a"), (link) => link.getAttribute("href"))).toEqual([
+		"/product",
+		"/benchmarks",
+		"/docs",
+		"/blog",
+	])
+	expect(Array.from(from.querySelectorAll("#highlights > article"), (article) => article.id)).toEqual([
+		"feature-safe",
+		"feature-fast",
+		"feature-tested",
+	])
+	expect(Array.from(from.querySelectorAll("#timeline li"), (item) => item.textContent?.trim())).toEqual([
+		"Launch notes published",
+		"Benchmarks verified",
+		"Examples expanded",
+	])
+	expect(from.querySelectorAll("main article")).toHaveLength(4)
+	expect(from.querySelector("#stories h3")?.textContent).toBe("Coverage")
+	expect(from.querySelector("footer small")?.textContent).toContain("2026")
+})

--- a/test/new/morph-inner.browser.test.ts
+++ b/test/new/morph-inner.browser.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "vitest"
+import { morphInner } from "../../src/morphlex"
+
+test("morphInner accepts a matching element string", () => {
+	const from = document.createElement("div")
+	from.innerHTML = "<span>before</span>"
+
+	morphInner(from, `<div><span>after</span><em>extra</em></div>`)
+
+	expect(from.innerHTML).toBe("<span>after</span><em>extra</em>")
+})
+
+test("morphInner rejects strings that are not a single element", () => {
+	const from = document.createElement("div")
+
+	expect(() => morphInner(from, `text only`)).toThrow("[Morphlex] The string was not a valid HTML element.")
+	expect(() => morphInner(from, `<div></div><div></div>`)).toThrow(
+		"[Morphlex] The string was not a valid HTML element.",
+	)
+})
+
+test("morphInner rejects mismatched element names", () => {
+	const from = document.createElement("div")
+	const to = document.createElement("span")
+
+	expect(() => morphInner(from, to)).toThrow("[Morphlex] You can only do an inner morph with matching elements.")
+})

--- a/test/new/morph-inner.browser.test.ts
+++ b/test/new/morph-inner.browser.test.ts
@@ -14,9 +14,7 @@ test("morphInner rejects strings that are not a single element", () => {
 	const from = document.createElement("div")
 
 	expect(() => morphInner(from, `text only`)).toThrow("[Morphlex] The string was not a valid HTML element.")
-	expect(() => morphInner(from, `<div></div><div></div>`)).toThrow(
-		"[Morphlex] The string was not a valid HTML element.",
-	)
+	expect(() => morphInner(from, `<div></div><div></div>`)).toThrow("[Morphlex] The string was not a valid HTML element.")
 })
 
 test("morphInner rejects mismatched element names", () => {

--- a/test/new/no-matches.browser.test.ts
+++ b/test/new/no-matches.browser.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "vitest"
+import { morph } from "../../src/morphlex"
+
+test("completely unmatched children are removed and inserted", () => {
+	const from = document.createElement("div")
+	from.appendChild(document.createComment("old"))
+
+	const to = document.createElement("div")
+	to.appendChild(document.createElement("span"))
+
+	morph(from, to)
+
+	expect(from.childNodes).toHaveLength(1)
+	expect(from.firstChild?.nodeName).toBe("SPAN")
+})

--- a/test/new/non-element-matching.browser.test.ts
+++ b/test/new/non-element-matching.browser.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "vitest"
+import { morph } from "../../src/morphlex"
+
+test("equal non-element nodes are skipped by the nodeType fallback pass", () => {
+	const from = document.createElement("div")
+	const comment = document.createComment("same")
+	from.append(comment)
+
+	const to = document.createElement("div")
+	to.append(document.createComment("same"))
+
+	morph(from, to)
+
+	expect(from.firstChild).toBe(comment)
+	expect(from.firstChild?.nodeValue).toBe("same")
+})
+
+test("same-type non-element nodes fall back to morphing by nodeType", () => {
+	const from = document.createElement("div")
+	const comment = document.createComment("before")
+	from.append(comment)
+
+	const to = document.createElement("div")
+	to.append(document.createComment("after"))
+
+	morph(from, to)
+
+	expect(from.firstChild).toBe(comment)
+	expect(from.firstChild?.nodeValue).toBe("after")
+})
+
+test("nodeType fallback skips mismatched non-element candidates before finding a match", () => {
+	const from = document.createElement("div")
+	const comment = document.createComment("comment")
+	const text = document.createTextNode("before")
+	from.append(comment, text)
+
+	const to = document.createElement("div")
+	to.append(document.createTextNode("after"))
+
+	morph(from, to)
+
+	expect(from.childNodes).toHaveLength(1)
+	expect(from.firstChild).toBe(text)
+	expect(from.textContent).toBe("after")
+})
+
+test("direct morphs to non-parent targets are a no-op", () => {
+	const from = document.createElement("div")
+	from.textContent = "before"
+
+	morph(from, document.createTextNode("after"))
+
+	expect(from.textContent).toBe("before")
+})

--- a/test/new/tagname-exclusions.browser.test.ts
+++ b/test/new/tagname-exclusions.browser.test.ts
@@ -168,49 +168,55 @@ test("input elements with matching id are still reused", () => {
 	expect(a.children[0]).toBe(original)
 })
 
-test.skipIf(!("attachInternals" in HTMLElement.prototype))("form-associated custom elements in the from-side are not matched by tag name", () => {
-	class MyControl extends HTMLElement {
-		static formAssociated = true
-		constructor() {
-			super()
-			this.attachInternals()
+test.skipIf(!("attachInternals" in HTMLElement.prototype))(
+	"form-associated custom elements in the from-side are not matched by tag name",
+	() => {
+		class MyControl extends HTMLElement {
+			static formAssociated = true
+			constructor() {
+				super()
+				this.attachInternals()
+			}
 		}
-	}
-	if (!customElements.get("my-control")) {
-		customElements.define("my-control", MyControl)
-	}
+		if (!customElements.get("my-control")) {
+			customElements.define("my-control", MyControl)
+		}
 
-	const a = document.createElement("div")
-	const control = document.createElement("my-control")
-	control.setAttribute("class", "old")
-	a.appendChild(control)
+		const a = document.createElement("div")
+		const control = document.createElement("my-control")
+		control.setAttribute("class", "old")
+		a.appendChild(control)
 
-	const b = dom(`<div><my-control class="new"></my-control></div>`)
+		const b = dom(`<div><my-control class="new"></my-control></div>`)
 
-	morph(a, b)
+		morph(a, b)
 
-	// The from-side custom element is form-associated, so it should not
-	// be matched by tag name — it should be replaced
-	expect(a.children[0]).not.toBe(control)
-	expect(a.children[0]!.className).toBe("new")
-})
+		// The from-side custom element is form-associated, so it should not
+		// be matched by tag name — it should be replaced
+		expect(a.children[0]).not.toBe(control)
+		expect(a.children[0]!.className).toBe("new")
+	},
+)
 
-test.skipIf(!("attachInternals" in HTMLElement.prototype))("non-form-associated custom elements are still matched by tag name", () => {
-	class MyWidget extends HTMLElement {}
-	if (!customElements.get("my-widget")) {
-		customElements.define("my-widget", MyWidget)
-	}
+test.skipIf(!("attachInternals" in HTMLElement.prototype))(
+	"non-form-associated custom elements are still matched by tag name",
+	() => {
+		class MyWidget extends HTMLElement {}
+		if (!customElements.get("my-widget")) {
+			customElements.define("my-widget", MyWidget)
+		}
 
-	const a = document.createElement("div")
-	const widget = document.createElement("my-widget")
-	widget.setAttribute("class", "old")
-	a.appendChild(widget)
+		const a = document.createElement("div")
+		const widget = document.createElement("my-widget")
+		widget.setAttribute("class", "old")
+		a.appendChild(widget)
 
-	const b = dom(`<div><my-widget class="new"></my-widget></div>`)
+		const b = dom(`<div><my-widget class="new"></my-widget></div>`)
 
-	morph(a, b)
+		morph(a, b)
 
-	// Non-form-associated custom element — should still match by tag name
-	expect(a.children[0]).toBe(widget)
-	expect(a.children[0]!.className).toBe("new")
-})
+		// Non-form-associated custom element — should still match by tag name
+		expect(a.children[0]).toBe(widget)
+		expect(a.children[0]!.className).toBe("new")
+	},
+)

--- a/test/new/textarea.browser.test.ts
+++ b/test/new/textarea.browser.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "vitest"
+import { morph } from "../../src/morphlex"
+
+test("preserveChanges keeps a modified textarea value", () => {
+	const from = document.createElement("textarea")
+	from.defaultValue = "before"
+	from.value = "user edit"
+
+	const to = document.createElement("textarea")
+	to.textContent = "after"
+
+	morph(from, to, { preserveChanges: true })
+
+	expect(from.defaultValue).toBe("after")
+	expect(from.value).toBe("user edit")
+})
+
+test("textarea morph handles an empty target value", () => {
+	const from = document.createElement("textarea")
+	from.defaultValue = "before"
+	from.value = "before"
+
+	const to = document.createElement("textarea")
+
+	morph(from, to)
+
+	expect(from.defaultValue).toBe("")
+	expect(from.value).toBe("")
+})
+
+test("textarea morph skips rewriting identical text content", () => {
+	const from = document.createElement("textarea")
+	from.defaultValue = "same"
+	from.value = "same"
+	from.setAttribute("data-from", "1")
+
+	const to = document.createElement("textarea")
+	to.textContent = "same"
+	to.setAttribute("data-to", "1")
+
+	morph(from, to)
+
+	expect(from.defaultValue).toBe("same")
+	expect(from.value).toBe("same")
+	expect(from.getAttribute("data-to")).toBe("1")
+})

--- a/test/new/whitespace.browser.test.ts
+++ b/test/new/whitespace.browser.test.ts
@@ -66,3 +66,25 @@ test("whitespace is reused when both have whitespace", () => {
 	expect(from.childNodes[1]).toBe(originalTextNode1)
 	expect(from.childNodes[3]).toBe(originalTextNode2)
 })
+
+test("empty text nodes are treated as whitespace and removed", () => {
+	const from = document.createElement("div")
+	from.append(document.createTextNode(""), document.createElement("span"))
+
+	const to = dom(`<div><span></span></div>`)
+
+	morph(from, to)
+
+	expect(from.childNodes).toHaveLength(1)
+	expect(from.firstChild?.nodeName).toBe("SPAN")
+})
+
+test("unicode whitespace text nodes are treated as whitespace", () => {
+	const from = dom(`<div><span>A</span>&nbsp;<span>B</span></div>`)
+	const to = dom(`<div><span>A</span><span>B</span></div>`)
+
+	morph(from, to)
+
+	expect(from.childNodes).toHaveLength(2)
+	expect(from.textContent).toBe("AB")
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,8 @@ export default defineConfig({
 		globals: true,
 		testTimeout: 10000,
 		hookTimeout: 10000,
+		coverage: {
+			include: ["src/morphlex.ts"],
+		},
 	},
 })


### PR DESCRIPTION
Protect detached-node callback behavior and no-op character data semantics while bringing src/morphlex.ts to full coverage with focused browser-first tests.